### PR TITLE
delete `set nocompatible`

### DIFF
--- a/config/nvim/init.vim
+++ b/config/nvim/init.vim
@@ -1,5 +1,3 @@
-set nocompatible
-
 " Has to be here so that plugins can use it
 let mapleader=" "
 


### PR DESCRIPTION
Referenced your vimrc to split my vimrc. So thanks! 😊 

Noticed an unnecessary line in your `init.vim`. You can check it with `:h nocompatible` or on [reddit-vim-wiki](https://www.reddit.com/r/vim/wiki/vimrctips).